### PR TITLE
fix: 处理资源总数和实际资源总数对不上问题

### DIFF
--- a/app/service/resources.js
+++ b/app/service/resources.js
@@ -64,7 +64,8 @@ module.exports = app => {
                 from tb_resources r 
                 left join tb_res_tags_rel rel on r.id=rel.rid 
                 left join tb_tags t on rel.tid=t.id 
-                where ${sqlQuery}`, { type: 'SELECT', replacements: query });
+                where ${sqlQuery}
+                GROUP BY r.id `, { type: 'SELECT', replacements: query });
       // 查询列表数据
       var list = yield this.ctx.model.query(sql, { type: 'SELECT', replacements: query }) || []
       list = list.map(it => {
@@ -74,7 +75,7 @@ module.exports = app => {
         })) : []
         return it
       })
-      return { total: total[ 0 ].counts, list };
+      return { total: total.length, list };
     }
 
     * save (query) {


### PR DESCRIPTION
在编辑器背景图片选择那里，弹出来的“所有列表”tab里面的图片实际数量和左下角的“共xx条”对不上，发现是sql那里，列表有一个group by，而总数那里没有，导致把重复的条数也算进去了总数